### PR TITLE
Use correct capitalization of this header

### DIFF
--- a/MCUME_pico/display/pico_dsp.cpp
+++ b/MCUME_pico/display/pico_dsp.cpp
@@ -17,7 +17,7 @@
 #include "hardware/irq.h"
 #include <string.h>
 
-#include "PICO_DSP.h"
+#include "pico_dsp.h"
 #include "font8x8.h"
 #include "include.h"
 

--- a/MCUME_pico2/display/pico_dsp.cpp
+++ b/MCUME_pico2/display/pico_dsp.cpp
@@ -17,7 +17,7 @@
 #include "hardware/irq.h"
 #include <string.h>
 
-#include "PICO_DSP.h"
+#include "pico_dsp.h"
 #include "font8x8.h"
 #include "include.h"
 


### PR DESCRIPTION
On Linux systems, include files are case sensitive. This avoids a build error including the pico_dsp header.